### PR TITLE
Add E chord button to ukulele practice

### DIFF
--- a/ukulele-practice.jsx
+++ b/ukulele-practice.jsx
@@ -1,7 +1,7 @@
 const { useState, useEffect, useRef } = React;
 
 function UkulelePractice() {
-  const allChords = ['C', 'Am', 'F', 'G', 'D', 'Em', 'A', 'Dm', 'D7', 'G7'];
+  const allChords = ['C', 'Am', 'F', 'G', 'D', 'Em', 'E', 'A', 'Dm', 'D7', 'G7'];
   
   const [selectedChords, setSelectedChords] = useState(['C', 'Am', 'F', 'G']);
   const [currentChord, setCurrentChord] = useState('');


### PR DESCRIPTION
Adds the E chord button to the ukulele practice chord selection section.

Closes #4

Generated with [Claude Code](https://claude.ai/code)