### PR TITLE
Fix beat counter ignoring beatsPerChord setting

### DIFF
--- a/ukulele-practice.jsx
+++ b/ukulele-practice.jsx
@@ -36,7 +36,7 @@ function UkulelePractice() {
       
       beatInterval = setInterval(() => {
         setCurrentBeat(prev => {
-          if (prev >= 4) {
+          if (prev >= beatsPerChord) {
             return 1;
           }
           return prev + 1;
@@ -46,7 +46,7 @@ function UkulelePractice() {
       setCurrentBeat(0);
     }
     return () => clearInterval(beatInterval);
-  }, [isPlaying, bpm]);
+  }, [isPlaying, bpm, beatsPerChord]);
 
   // Chord rotation based on BPM
   useEffect(() => {
@@ -129,8 +129,8 @@ function UkulelePractice() {
               </div>
               
               {/* Beat Indicator */}
-              <div className="flex justify-center items-center gap-6 mb-6">
-                {Array.from({ length: 4 }, (_, i) => {
+              <div className="flex justify-center items-center gap-6 mb-6 flex-wrap">
+                {Array.from({ length: beatsPerChord }, (_, i) => {
                   const beatNum = i + 1;
                   const isActive = currentBeat === beatNum;
                   


### PR DESCRIPTION
The beat counter rollover was hardcoded to 4, so beats reset after beat 4 regardless of the Beats per Chord setting.

**Changes:**
- Drive rollover from `beatsPerChord` instead of hardcoded 4
- Add `beatsPerChord` to the effect dependency array so it re-runs when changed
- Render the correct number of beat indicator dots (matching the Beats per Chord setting)

Spotted during review of #5.

Generated with [Claude Code](https://claude.ai/code)